### PR TITLE
Add a way to define the binary main

### DIFF
--- a/pacha.js
+++ b/pacha.js
@@ -3504,7 +3504,16 @@ const executeCommand = async (text) => {
       let gptOutput = '';
   
     
-    const command = './main';
+    // Read args if we find --binary then use the next path instead of ./main
+    let command = './main';
+    let previous_arg;
+    for(let arg of process.argv.slice(2)) {
+      if(previous_arg == "--binary") {
+        command = arg;
+      }
+      previous_arg = arg;
+    }
+
     const args = [
       '-m',
       path.join(modelsFolder, selectedModel),


### PR DESCRIPTION
Hello
The PR gives a way to have Pacha executable / js elsewhere and load the correct llama.cpp binary.

It's surely not the best way to do it.
But don't hesitate to make modifications if needed.

I don't know JS very well, so I just hacked that together because I store each GIT project separately and therefore I didn't want to add Pacha directly next to llama.cpp
